### PR TITLE
シーン遷移不具合を修正＋Addressableのシーンのロード、解放をテスト

### DIFF
--- a/Assets/Addressable/ActionGame/ActionGame.unity
+++ b/Assets/Addressable/ActionGame/ActionGame.unity
@@ -427,6 +427,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1900108500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1900108501}
+  - component: {fileID: 1900108502}
+  m_Layer: 0
+  m_Name: Scene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1900108501
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900108500}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.009094477, y: 0.89223534, z: -0.018988252}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1900108502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900108500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 085e74c016e8b86438fa6a36419681e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -434,3 +478,4 @@ SceneRoots:
   - {fileID: 330585546}
   - {fileID: 410087041}
   - {fileID: 832575519}
+  - {fileID: 1900108501}

--- a/Assets/Addressable/Title/Title.unity
+++ b/Assets/Addressable/Title/Title.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,6 +123,50 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &35996686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 35996687}
+  - component: {fileID: 35996688}
+  m_Layer: 0
+  m_Name: Scene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &35996687
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 35996686}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.009094477, y: 0.89223534, z: -0.018988252}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &35996688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 35996686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acf1897b6abd24a4188f08df2f8aea7b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &374541895
 GameObject:
   m_ObjectHideFlags: 0
@@ -133,6 +177,7 @@ GameObject:
   m_Component:
   - component: {fileID: 374541897}
   - component: {fileID: 374541896}
+  - component: {fileID: 374541898}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -217,6 +262,29 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &374541898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374541895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1 &1061828031
 GameObject:
   m_ObjectHideFlags: 0
@@ -315,3 +383,4 @@ SceneRoots:
   m_Roots:
   - {fileID: 1061828034}
   - {fileID: 374541897}
+  - {fileID: 35996687}

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -38,7 +38,7 @@ MonoBehaviour:
     m_Id: 
   m_RemoteCatalogLoadPath:
     m_Id: 
-  m_ContentStateBuildPathProfileVariableName: 
+  m_ContentStateBuildPathProfileVariableName: <default settings path>
   m_CustomContentStateBuildPath: 
   m_ContentStateBuildPath: 
   m_BuildAddressablesWithPlayerBuild: 0

--- a/Assets/Runtime/Script/Scene/ActionGameScene.cs
+++ b/Assets/Runtime/Script/Scene/ActionGameScene.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using Project.Utilities;
+using UnityEngine;
+
+namespace Project
+{
+    public class ActionGameScene : SceneBase
+    {
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Return))
+            {
+                SceneTransitionController.Transition(SceneDefine.Title).Forget();
+            }
+        }
+    }
+}

--- a/Assets/Runtime/Script/Scene/ActionGameScene.cs.meta
+++ b/Assets/Runtime/Script/Scene/ActionGameScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 085e74c016e8b86438fa6a36419681e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Runtime/Script/Scene/Title/TitleScene.cs
+++ b/Assets/Runtime/Script/Scene/Title/TitleScene.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using Project.System;
+using Project.Utilities;
 using UnityEngine;
 using NotImplementedException = System.NotImplementedException;
 
@@ -9,9 +10,12 @@ namespace Project.Title
 {
     public class TitleScene : SceneBase
     {
-        public override async UniTask Prepare(IAssetsLoader loader, object sceneData = null)
+        private void Update()
         {
-            await base.Prepare(loader, sceneData);
+            if (Input.GetKeyDown(KeyCode.Backspace))
+            {
+                SceneTransitionController.Back().Forget();
+            }
         }
     }
 }

--- a/Assets/Runtime/Script/System/AddressableLoader.cs
+++ b/Assets/Runtime/Script/System/AddressableLoader.cs
@@ -64,7 +64,7 @@ namespace Project.System
 
         public async UniTask<Scene> LoadSceneAsync(string path)
         {
-            AsyncOperationHandle<SceneInstance> handle = Addressables.LoadSceneAsync(path, LoadSceneMode.Additive, false);
+            AsyncOperationHandle<SceneInstance> handle = Addressables.LoadSceneAsync(path, LoadSceneMode.Additive);
             await UniTask.WaitUntil(() => handle.IsDone);
             if (handle.Status == AsyncOperationStatus.Failed)
             {

--- a/Assets/Runtime/Script/System/SceneBase.cs
+++ b/Assets/Runtime/Script/System/SceneBase.cs
@@ -14,16 +14,19 @@ namespace Project
         protected object data;
         public object Data => data;
         public SceneAssetLoader AssetLoader { get; private set; }
+        public SceneTransitionController SceneTransitionController { get; private set; }
 
         /// <summary>
         /// 初期化
         /// </summary>
         /// <param name="loader">アセットLoader</param>
+        /// <param name="sceneTransitionController"></param>
         /// <param name="sceneData">シーンデータ</param>
         /// <returns></returns>
-        public virtual UniTask Prepare(IAssetsLoader loader, object sceneData = null)
+        public virtual UniTask Prepare(IAssetsLoader loader, SceneTransitionController sceneTransitionController, object sceneData = null)
         {
             AssetLoader = new SceneAssetLoader(loader);
+            SceneTransitionController = sceneTransitionController;
             data = sceneData;
             return UniTask.CompletedTask;
         }

--- a/Assets/Runtime/Script/System/SceneTransitionController.cs
+++ b/Assets/Runtime/Script/System/SceneTransitionController.cs
@@ -16,6 +16,7 @@ namespace Project.System
     {
         private readonly List<SceneDefine> history = new List<SceneDefine>();
         public SceneDefine CurrentSceneDefine { get; private set; }
+        private Scene currentScene;
         private SceneBase currentSceneBase;
         private readonly IAssetsLoader loader;
         public bool HasBackScene => history.Count > 1;  //戻れるシーンはあるか？
@@ -25,10 +26,13 @@ namespace Project.System
         {
             this.loader = loader;
 
+            currentScene = startScene;
             currentSceneBase = startSceneBase;
             Enum.TryParse(startScene.name, out SceneDefine define);
             CurrentSceneDefine = define;
             history.Add(CurrentSceneDefine);
+
+            currentSceneBase.Prepare(loader, this);
         }
 
         /// <summary>
@@ -37,7 +41,7 @@ namespace Project.System
         /// <param name="sceneDefine"></param>
         /// <param name="sceneData"></param>
         /// <param name="isResetHistory"></param>
-        public async UniTask Transition(SceneDefine sceneDefine, object sceneData, bool isResetHistory = false)
+        public async UniTask Transition(SceneDefine sceneDefine, object sceneData = null, bool isResetHistory = false)
         {
             // シーンをロード
             var result = await LoadScene(sceneDefine);
@@ -53,20 +57,21 @@ namespace Project.System
             }
             
             UnloadCurrentScene();
+            SceneManager.UnloadSceneAsync(currentScene);
 
             // シーン初期化
+            currentScene = result.scene;
             CurrentSceneDefine = sceneDefine;
             currentSceneBase = result.sceneBase;
             history.Add(sceneDefine);
-            await currentSceneBase.Prepare(loader, sceneData);
-            SceneManager.SetActiveScene(result.scene);
+            await currentSceneBase.Prepare(loader, this, sceneData);
         }
 
         /// <summary>
         /// 前のシーンに戻る
         /// </summary>
         /// <param name="sceneData"></param>
-        public async UniTask Back(object sceneData)
+        public async UniTask Back(object sceneData = null)
         {
             // 戻れるシーンを取得
             if (!HasBackScene)
@@ -85,13 +90,14 @@ namespace Project.System
             }
             
             UnloadCurrentScene();
+            SceneManager.UnloadSceneAsync(currentScene);
             
             // シーン初期化
+            currentScene = result.scene;
             CurrentSceneDefine = sceneDefine;
             currentSceneBase = result.sceneBase;
-            await currentSceneBase.Prepare(loader, sceneData);
+            await currentSceneBase.Prepare(loader, this, sceneData);
             await currentSceneBase.BackFromNext();  // 前のシーンに戻る際の処理
-            SceneManager.SetActiveScene(result.scene);
         }
 
         private async UniTask<(bool isSucceeded, Scene scene, SceneBase sceneBase)> LoadScene(SceneDefine sceneDefine)
@@ -99,6 +105,7 @@ namespace Project.System
             // 次のシーンをロード
             string scenePath = GetScenePath(sceneDefine);
             Scene scene = await loader.LoadSceneAsync(scenePath);
+            
             GameObject sceneObject = scene.GetRootGameObjects().FirstOrDefault(rootObject => rootObject.name == "Scene");    // SceneBaseがアタッチしているオブジェクトの名前は必ず「Scene」になる
             if (sceneObject == null)
             {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.7.0",
+    "com.unity.profiling.core": "1.0.2",
     "com.unity.render-pipelines.universal": "14.0.10",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.8",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -102,6 +102,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.profiling.core": {
+      "version": "1.0.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.render-pipelines.core": {
       "version": "14.0.10",
       "depth": 1,


### PR DESCRIPTION
レビューお願いいたします

## 概要
不具合：シーン遷移後の初期化及び前のシーンの破棄はうまく機能しない
## 確認したこと
・シーン遷移の不具合が解消されたこと
・Addressableのプロファイラーで、ActionGame<->Title のシーン遷移を繰り返しても、メモリリークは起きず、ロードしたシーンが解放される
## 使い方・確認方法

## 保留する内容・今後やること

## タスクリンクや参考リンク