### PR TITLE
Unityバージョンを2022.3.21f1にアップし、インクリメンタル GCにした

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -835,7 +835,7 @@ PlayerSettings:
   useDeterministicCompilation: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
-  gcIncremental: 0
+  gcIncremental: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.19f1
-m_EditorVersionWithRevision: 2022.3.19f1 (244b723c30a6)
+m_EditorVersion: 2022.3.21f1
+m_EditorVersionWithRevision: 2022.3.21f1 (bf09ca542b87)


### PR DESCRIPTION
レビューお願いいたします

## 概要
Editorでゲーム実行時、周期的に一瞬重くなる現象を発見し
Unityバージョンを2022.3.21f1にアップし、インクリメンタル GCにしたことで解決した

原因：
ProfileのEdit Modeで、スパイクが出現時、一番重い処理はEditorLoopのGC.Collectだった
## 確認したこと
修正後、周期的に一瞬重くなる現象はなくなった
## 使い方・確認方法

## 保留する内容・今後やること

## タスクリンクや参考リンク